### PR TITLE
Save feedtoken during generate session

### DIFF
--- a/SmartApi/smartConnect.py
+++ b/SmartApi/smartConnect.py
@@ -241,7 +241,7 @@ class SmartConnect(object):
             self.setUserId(id)
             user['data']['jwtToken']="Bearer "+jwtToken
             user['data']['refreshToken']=refreshToken
-
+            user['data']['feedToken'] = feedToken
             
             return user
         else:


### PR DESCRIPTION
As per documents login response returns feedtoken also but that's not saved to same instance. 
If we save feedtoken from login response it will save another request to API.